### PR TITLE
Exclude build subpackages to prevent build/lib recursion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ exclude = [
     "_build",
     "buck-out",
     "build",
+    "build*",
     "dist",
     "node_modules",
     "site-packages",


### PR DESCRIPTION
 See: https:/…/github.com/pypa/setuptools/issues/4076

Adding `"build*"` to `exclude` prevents compounding `build`/`lib` recursion with repeated uninstallation/installation.