### PR TITLE
mypy pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,9 @@ repos:
         args: [check, --select, I, --fix]
       - id: ruff-format
         name: format with ruff
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.13.0
+    hooks:
+      - id: mypy
+        args: [--strict, --ignore-missing-imports, --explicit-package-bases]
+        additional_dependencies: []

--- a/pymatgen/io/espresso/outputs/projwfc.py
+++ b/pymatgen/io/espresso/outputs/projwfc.py
@@ -360,7 +360,7 @@ class Projwfc(MSONable):
                 filename,
                 skiprows=skip,
                 header=None,
-                sep=r'\s+',
+                sep=r"\s+",
                 names=columns,
                 dtype=str,
             )

--- a/tests/test_pwin.py
+++ b/tests/test_pwin.py
@@ -15,7 +15,6 @@ from pymatgen.io.espresso.inputs.pwin import (
     KPointsCard,
 )
 from pymatgen.io.espresso.utils import IbravUntestedWarning
-from pymatgen.io.espresso.inputs.base import EspressoInputWarning
 
 
 @parametrize_cases(
@@ -118,7 +117,7 @@ def test_pwin_parser(mat, ibrav, alat, symbols, valid):
     Test the PWin parser for different materials and ibrav values.
     Tests the structures and alat, as well as some warnings and exceptions
     """
-    
+
     # This is not great...
     try:
         pwin = PWin.from_file(f"tests/data/{mat}/bands.in")
@@ -128,14 +127,14 @@ def test_pwin_parser(mat, ibrav, alat, symbols, valid):
     with pytest.warns(IbravUntestedWarning) if ibrav > 0 else contextlib.nullcontext():
         s1 = pwin.structure
     s2 = Structure.from_file(f"tests/data/{mat}/POSCAR")
-    
+
     # Test warning for ibrav != 0
     with pytest.warns(IbravUntestedWarning) if ibrav != 0 else contextlib.nullcontext():
         s1 = pwin.structure
     s2 = Structure.from_file(f"tests/data/{mat}/POSCAR")
     # Assert structure is parsed correctly
     assert s1 == s2
-    
+
     # Assert that alat is parsed correctly or raises ValueError
     with contextlib.nullcontext() if alat else pytest.raises(ValueError):
         assert pwin.alat == pytest.approx(alat)


### PR DESCRIPTION
### Notes

- [ ] pytest_paramatrize_cases can't be type checked?
- [ ] Subclasses of `InputNamelist` overwrite properties
- [ ] There's quite a bit of abstraction for the input classes. Makes it difficult to understand the code.